### PR TITLE
fix: ignore python Style Comments

### DIFF
--- a/packvers/requirements.py
+++ b/packvers/requirements.py
@@ -17,7 +17,7 @@ from pyparsing import (  # noqa
     ZeroOrMore,
     originalTextFor,
     stringEnd,
-    stringStart,
+    stringStart, pythonStyleComment,
 )
 
 from .markers import MARKER_EXPR, Marker
@@ -78,7 +78,8 @@ URL_AND_MARKER = URL + Optional(MARKER)
 
 NAMED_REQUIREMENT = NAME + Optional(EXTRAS) + (URL_AND_MARKER | VERSION_AND_MARKER)
 
-REQUIREMENT = stringStart + NAMED_REQUIREMENT + stringEnd
+REQUIREMENT = stringEnd | (stringStart + NAMED_REQUIREMENT + stringEnd)
+REQUIREMENT.ignore(pythonStyleComment)
 # pyparsing isn't thread safe during initialization, so we do it eagerly, see
 # issue #104
 REQUIREMENT.parseString("x[]")


### PR DESCRIPTION
Changed the rule/grammar to order Python Styled Comments.
Closes: https://github.com/nexB/python-inspector/pull/166